### PR TITLE
Fix 'module' path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "cross-env NODE_ENV=test nyc mocha --require babel-register --require babel-polyfill"
   },
   "jsnext:main": "./src/utils.js",
-  "module": "./src/index.js",
+  "module": "./src/utils.js",
   "main": "./build/utils.js",
   "devDependencies": {
     "babel-cli": "latest",


### PR DESCRIPTION
The `module` field in `package.json` references an `index.js` that does not exist (it should be `utils.js`). This prohibits use of e.g. `pkijs` with [rollup-plugin-node-resolve](https://github.com/rollup/rollup-plugin-node-resolve) with `module: true` (which is the default).